### PR TITLE
fix: tournament presentation — featured block, live/ended split, dead links

### DIFF
--- a/src/app/(pages)/tournaments/[tournament_id]/page.tsx
+++ b/src/app/(pages)/tournaments/[tournament_id]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import Image from "next/image";
@@ -466,6 +466,23 @@ export default function TournamentDetailPage() {
 
   const tournamentEnded = isTournamentEnded();
 
+  // Scraper offsets sort.deadline by -24h from the real BaT end. We
+  // compensate here so "Live vs Ended" reflects the true auction state, not
+  // the stale scraper timestamp. This keeps expired cars out of the Live
+  // column even when the tournament endTime is further out.
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const auctionRealEnd = (a: Auction): number => {
+    const raw = a.sort?.deadline;
+    if (!raw) return 0;
+    return new Date(raw).getTime() + DAY_MS;
+  };
+  const liveAuctions = auctions
+    .filter((a) => auctionRealEnd(a) > Date.now())
+    .sort((a, b) => auctionRealEnd(a) - auctionRealEnd(b));
+  const endedAuctions = auctions
+    .filter((a) => auctionRealEnd(a) <= Date.now())
+    .sort((a, b) => auctionRealEnd(b) - auctionRealEnd(a));
+
   return (
     <div className="container mx-auto px-4 py-12">
       <Button variant="ghost" className="mb-8" onClick={() => router.back()}>
@@ -652,56 +669,137 @@ export default function TournamentDetailPage() {
       <div className="grid gap-8 md:grid-cols-12">
         {/* Left Column: Auctions */}
         <div className="md:col-span-7">
-          <h2 className="mb-6 text-2xl font-bold">
-            TOURNAMENT CARS ({auctions.length})
-          </h2>
-          <div className="space-y-6">
-            {auctions.map((auction, index) => (
-              <Card
-                key={auction._id}
-                className="overflow-hidden border-white/[0.08] bg-[#16181f]"
-              >
-                <div className="grid grid-cols-1 sm:grid-cols-5">
-                  <div className="relative h-48 sm:col-span-2 sm:h-auto">
-                    <Image
-                      src={auction.image}
-                      alt={auction.title}
-                      fill
-                      className="object-cover"
-                    />
-                  </div>
-                  <div className="p-4 sm:col-span-3">
-                    <h3 className="mb-2 font-bold">{auction.title}</h3>
-                    <div className="mb-4 grid grid-cols-2 gap-2">
-                      <div>
-                        <div className="text-xs text-gray-400">Current Bid</div>
-                        <div className="font-['JetBrains_Mono'] font-bold text-[#00D4AA]">
-                          ${(auction.sort?.price ?? auction.attributes?.[0]?.value ?? 0).toLocaleString()}
-                        </div>
-                      </div>
-                      <div>
-                        <div className="text-xs text-gray-400">Ends</div>
-                        <div className="text-sm">
-                          {auction.sort?.deadline
-                            ? formatDistanceToNow(new Date(auction.sort.deadline), {
-                                addSuffix: true
-                              })
-                            : "N/A"}
-                        </div>
-                      </div>
+          <div className="mb-6 flex items-baseline justify-between">
+            <h2 className="text-2xl font-bold">TOURNAMENT CARS</h2>
+            <p className="text-sm text-gray-400">
+              {liveAuctions.length} live · {endedAuctions.length} ended
+            </p>
+          </div>
+
+          {auctions.length === 0 ? (
+            <Card className="border-white/[0.08] bg-[#16181f] p-8 text-center">
+              <Trophy className="mx-auto mb-3 h-10 w-10 text-gray-600" />
+              <h3 className="mb-2 text-lg font-bold text-white">
+                {tournamentEnded ? "Tournament results below" : "Cars loading soon"}
+              </h3>
+              <p className="text-sm text-gray-400">
+                {tournamentEnded
+                  ? "All cars in this tournament have concluded. Check the leaderboard to see how predictions landed."
+                  : "Auction data is still syncing. Check back in a few minutes."}
+              </p>
+            </Card>
+          ) : (
+            <>
+              {/* Live auctions — primary focus, sorted by urgency */}
+              {liveAuctions.length > 0 && (
+                <div className="mb-10">
+                  {liveAuctions.length !== auctions.length && (
+                    <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-[#00D4AA]">
+                      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#00D4AA]" />
+                      Live · accepting predictions
                     </div>
-                    <Link
-                      href={`/auction_details?id=${auction._id}`}
-                      className="flex items-center text-[#E94560] hover:underline"
-                    >
-                      View Details
-                      <ChevronRight className="ml-1 h-4 w-4" />
-                    </Link>
+                  )}
+                  <div className="space-y-6">
+                    {liveAuctions.map((auction) => (
+                      <Card
+                        key={auction._id}
+                        className="overflow-hidden border-white/[0.08] bg-[#16181f]"
+                      >
+                        <div className="grid grid-cols-1 sm:grid-cols-5">
+                          <div className="relative h-48 sm:col-span-2 sm:h-auto">
+                            <Image
+                              src={auction.image}
+                              alt={auction.title}
+                              fill
+                              className="object-cover"
+                            />
+                          </div>
+                          <div className="p-4 sm:col-span-3">
+                            <h3 className="mb-2 font-bold">{auction.title}</h3>
+                            <div className="mb-4 grid grid-cols-2 gap-2">
+                              <div>
+                                <div className="text-xs text-gray-400">Current Bid</div>
+                                <div className="font-['JetBrains_Mono'] font-bold text-[#00D4AA]">
+                                  ${(auction.sort?.price ?? auction.attributes?.[0]?.value ?? 0).toLocaleString()}
+                                </div>
+                              </div>
+                              <div>
+                                <div className="text-xs text-gray-400">Ends</div>
+                                <div className="text-sm">
+                                  {formatDistanceToNow(new Date(auctionRealEnd(auction)), {
+                                    addSuffix: true,
+                                  })}
+                                </div>
+                              </div>
+                            </div>
+                            <Link
+                              href={`/auctions/car_view_page/${auction._id}`}
+                              className="flex items-center text-[#E94560] hover:underline"
+                            >
+                              View Details
+                              <ChevronRight className="ml-1 h-4 w-4" />
+                            </Link>
+                          </div>
+                        </div>
+                      </Card>
+                    ))}
                   </div>
                 </div>
-              </Card>
-            ))}
-          </div>
+              )}
+
+              {/* Ended auctions — dimmed, collapsed visual */}
+              {endedAuctions.length > 0 && (
+                <div>
+                  <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    <span className="h-1.5 w-1.5 rounded-full bg-gray-500" />
+                    Ended · results final
+                  </div>
+                  <div className="space-y-3">
+                    {endedAuctions.map((auction) => (
+                      <Card
+                        key={auction._id}
+                        className="overflow-hidden border-white/[0.04] bg-[#16181f]/60 opacity-70 transition-opacity hover:opacity-100"
+                      >
+                        <div className="grid grid-cols-[80px_1fr_auto] items-center gap-3 p-3">
+                          <div className="relative h-16 w-20 overflow-hidden rounded">
+                            <Image
+                              src={auction.image}
+                              alt={auction.title}
+                              fill
+                              className="object-cover"
+                            />
+                          </div>
+                          <div className="min-w-0">
+                            <h3 className="truncate text-sm font-semibold text-white">
+                              {auction.title}
+                            </h3>
+                            <div className="mt-1 flex items-center gap-3 text-xs text-gray-400">
+                              <span className="font-['JetBrains_Mono'] text-[#00D4AA]">
+                                ${(auction.sort?.price ?? 0).toLocaleString()}
+                              </span>
+                              <span>
+                                Ended{" "}
+                                {formatDistanceToNow(new Date(auctionRealEnd(auction)), {
+                                  addSuffix: true,
+                                })}
+                              </span>
+                            </div>
+                          </div>
+                          <Link
+                            href={`/auctions/car_view_page/${auction._id}`}
+                            className="text-xs text-gray-400 hover:text-[#E94560]"
+                          >
+                            View
+                            <ChevronRight className="ml-0.5 inline h-3 w-3" />
+                          </Link>
+                        </div>
+                      </Card>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
+          )}
         </div>
 
         {/* Right Column: Predictions & Leaderboard */}

--- a/src/app/api/cars/route.ts
+++ b/src/app/api/cars/route.ts
@@ -21,23 +21,20 @@ export async function GET(req: NextRequest) {
 
     if (auction_ids) {
       const auction_ids_split = auction_ids.split(",");
-      // Try by _id first, then fall back to auction_id field
-      let auctions = await Auctions.find({
+      const objectIdMatches = await Auctions.find({
         _id: { $in: auction_ids_split.filter((id: string) => mongoose.isValidObjectId(id)) },
       });
-      if (auctions.length === 0) {
-        auctions = await Auctions.find({
-          auction_id: { $in: auction_ids_split },
-        });
+      const auctionIdMatches = await Auctions.find({
+        auction_id: { $in: auction_ids_split },
+      });
+      const byId = new Map<string, any>();
+      for (const a of [...objectIdMatches, ...auctionIdMatches]) {
+        byId.set(String(a._id), a);
       }
-
-      if (auctions.length === 0) {
-        return NextResponse.json(
-          { message: "No auctions found" },
-          { status: 404 }
-        );
-      }
-      return NextResponse.json(auctions);
+      // Return [] with 200 when nothing is found — stale tournament auction_ids
+      // are expected; callers render an empty-state instead of treating 404 as
+      // a fetch failure.
+      return NextResponse.json(Array.from(byId.values()));
     }
     // api/cars?auction_id=213123 to get a single car
     if (auction_id) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,8 @@ interface HomepageData {
   featuredTournament: {
     _id: string;
     name: string;
+    description?: string;
+    type?: string;
     startTime: string;
     endTime: string;
     calculatedPrizePool: number;
@@ -95,7 +97,7 @@ async function getHomepageData(userId: string | null): Promise<HomepageData> {
     activeTournaments,
     weeklyTournaments,
     totalPlayers,
-    featuredTournament,
+    featuredTournamentCandidates,
     trendingAuctions,
     recentWinnerTournaments,
     userRankResult,
@@ -119,12 +121,18 @@ async function getHomepageData(userId: string | null): Promise<HomepageData> {
     // Total players (fast estimate)
     Users.estimatedDocumentCount(),
 
-    // Featured tournament: next upcoming or current active
-    Tournaments.findOne({
+    // Featured tournament: rank-then-pick. We fetch the pool of active
+    // tournaments that haven't ended and score them in JS so a brand-new
+    // empty free_play tournament (which naturally has buyInFee=0 and
+    // users.length=0) doesn't trump a live paid tournament with real
+    // participants. Scoring below favors live > upcoming, and engagement
+    // over empty.
+    Tournaments.find({
       isActive: true,
       endTime: { $gt: now },
     })
       .sort({ startTime: 1 })
+      .limit(20)
       .lean(),
 
     // Trending auctions: qualifying makes, still live (scraper offsets deadline by -1 day)
@@ -206,6 +214,26 @@ async function getHomepageData(userId: string | null): Promise<HomepageData> {
       { $group: { _id: null, total: { $sum: '$totalVolume' } } },
     ]).toArray(),
   ]);
+
+  // Rank featured tournament candidates:
+  //   live + engaged   → 2000+ (beats everything)
+  //   live + empty     → 1000
+  //   upcoming+engaged →  500 + users
+  //   upcoming+empty   →  100
+  // Ties broken by startTime asc (sooner is better).
+  const featuredTournament = (featuredTournamentCandidates as any[])
+    .map((t) => {
+      const start = new Date(t.startTime).getTime();
+      const end = new Date(t.endTime).getTime();
+      const isLive = start <= now.getTime() && end > now.getTime();
+      const userCount = t.users?.length || 0;
+      const hasPool = (t.calculatedPrizePool || 0) > 0 || t.buyInFee > 0;
+      let score = isLive ? 1000 : 100;
+      if (userCount > 0) score += 1000 + Math.min(userCount, 50) * 10;
+      if (hasPool) score += 200;
+      return { t, score, start };
+    })
+    .sort((a, b) => b.score - a.score || a.start - b.start)[0]?.t ?? null;
 
   // Calculate weekly prize pool
   const weeklyPrizePool = weeklyTournaments.reduce((sum, t) => {
@@ -486,86 +514,165 @@ export default async function HomePage() {
 
       {/* ───────── Featured Tournament ───────── */}
       {data.featuredTournament ? (
-        <section className="bg-[#111111] py-16">
-          <div className="container mx-auto px-4">
-            <div className="mb-8 flex flex-col items-center gap-4 text-center sm:flex-row sm:justify-between sm:text-left">
-              <div>
-                <h2 className="text-3xl font-bold text-white">
-                  {data.featuredTournament.name}
-                </h2>
-                <p className="mt-1 text-gray-400">
-                  {new Date(data.featuredTournament.startTime).toLocaleDateString(
-                    "en-US",
-                    { month: "short", day: "numeric" }
-                  )}{" "}
-                  &ndash;{" "}
-                  {new Date(data.featuredTournament.endTime).toLocaleDateString(
-                    "en-US",
-                    { month: "short", day: "numeric", year: "numeric" }
-                  )}
-                </p>
-              </div>
-              <div className="flex flex-col items-center gap-3 sm:items-end">
-                <div className="font-mono text-4xl font-bold text-[#FFC553]">
-                  {formatCurrency(
-                    data.featuredTournament.calculatedPrizePool ||
-                      data.featuredTournament.buyInFee *
-                        (data.featuredTournament.users?.length || 0)
+        (() => {
+          const ft = data.featuredTournament;
+          const nowMs = Date.now();
+          const startMs = new Date(ft.startTime).getTime();
+          const endMs = new Date(ft.endTime).getTime();
+          const isLive = startMs <= nowMs && endMs > nowMs;
+          const isUpcoming = startMs > nowMs;
+          const userCount = ft.users?.length || 0;
+          const carCount = ft.auction_ids?.length || 0;
+          const isFreePlay = (ft.buyInFee || 0) === 0;
+          const prizePool =
+            ft.calculatedPrizePool ||
+            (ft.buyInFee || 0) * userCount;
+          return (
+            <section className="relative overflow-hidden bg-gradient-to-b from-[#0F0F1A] via-[#111111] to-[#0F0F1A] py-20">
+              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_top,_rgba(1,105,111,0.12),_transparent_55%)]" />
+              <div className="container relative mx-auto px-4">
+                {/* Eyebrow */}
+                <div className="mb-4 flex items-center justify-center gap-2">
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-[#01696F]/40 bg-[#01696F]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-[#00D4AA]">
+                    <Trophy className="h-3 w-3" />
+                    Featured Tournament
+                  </span>
+                  {isLive && (
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-[#E94560]/40 bg-[#E94560]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-[#E94560]">
+                      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#E94560]" />
+                      Live Now
+                    </span>
                   )}
                 </div>
-                <p className="text-xs uppercase tracking-wide text-gray-500">
-                  Prize Pool
-                </p>
-                {new Date(data.featuredTournament.startTime) > new Date() && (
-                  <CountdownTimer
-                    endTime={new Date(data.featuredTournament.startTime)}
-                    size="sm"
-                  />
-                )}
-              </div>
-            </div>
 
-            {/* Featured auction cards */}
-            {data.featuredAuctions.length > 0 && (
-              <div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
-                {data.featuredAuctions.map((auction) => (
-                  <div
-                    key={auction._id}
-                    className="overflow-hidden rounded-xl border border-white/[0.08] bg-[#16181f]"
-                  >
-                    {auction.image && (
-                      <div
-                        className="h-28 bg-cover bg-center"
-                        style={{
-                          backgroundImage: `url(${auction.image})`,
-                        }}
-                      />
-                    )}
-                    <div className="p-3">
-                      <p className="line-clamp-2 text-xs font-medium text-white">
-                        {auction.title}
-                      </p>
-                      {auction.sort?.price != null && (
-                        <p className="mt-1 font-mono text-xs text-gray-400">
-                          ${auction.sort.price.toLocaleString()}
+                {/* Hero header */}
+                <div className="mb-10 text-center">
+                  <h2 className="mx-auto max-w-3xl text-4xl font-bold leading-tight text-white sm:text-5xl">
+                    {ft.name}
+                  </h2>
+                  {ft.description && (
+                    <p className="mx-auto mt-3 max-w-2xl text-sm text-gray-400 sm:text-base">
+                      {ft.description}
+                    </p>
+                  )}
+                </div>
+
+                {/* Stat row */}
+                <div className="mx-auto mb-10 grid max-w-3xl grid-cols-2 gap-3 sm:grid-cols-4">
+                  {/* Prize / FREE PLAY */}
+                  <div className="rounded-xl border border-white/[0.08] bg-[#16181f] p-4 text-center sm:col-span-1">
+                    {isFreePlay ? (
+                      <>
+                        <div className="font-mono text-2xl font-bold text-[#00D4AA] sm:text-3xl">
+                          FREE
+                        </div>
+                        <p className="mt-1 text-[10px] uppercase tracking-wider text-gray-500">
+                          Play · No Buy-In
                         </p>
-                      )}
-                    </div>
+                      </>
+                    ) : (
+                      <>
+                        <div className="font-mono text-2xl font-bold text-[#FFC553] sm:text-3xl">
+                          {prizePool > 0 ? formatCurrency(prizePool) : `$${ft.buyInFee}`}
+                        </div>
+                        <p className="mt-1 text-[10px] uppercase tracking-wider text-gray-500">
+                          {prizePool > 0 ? "Prize Pool" : "Buy-In"}
+                        </p>
+                      </>
+                    )}
                   </div>
-                ))}
-              </div>
-            )}
+                  {/* Cars */}
+                  <div className="rounded-xl border border-white/[0.08] bg-[#16181f] p-4 text-center">
+                    <div className="font-mono text-2xl font-bold text-white sm:text-3xl">
+                      {carCount}
+                    </div>
+                    <p className="mt-1 text-[10px] uppercase tracking-wider text-gray-500">
+                      {carCount === 1 ? "Car" : "Cars"}
+                    </p>
+                  </div>
+                  {/* Players */}
+                  <div className="rounded-xl border border-white/[0.08] bg-[#16181f] p-4 text-center">
+                    <div className="font-mono text-2xl font-bold text-white sm:text-3xl">
+                      {userCount}
+                    </div>
+                    <p className="mt-1 text-[10px] uppercase tracking-wider text-gray-500">
+                      {userCount === 1 ? "Player" : "Players"}
+                    </p>
+                  </div>
+                  {/* Timer */}
+                  <div className="rounded-xl border border-white/[0.08] bg-[#16181f] p-4 text-center">
+                    <div className="flex h-[36px] items-center justify-center">
+                      <CountdownTimer
+                        endTime={new Date(isUpcoming ? ft.startTime : ft.endTime)}
+                        size="sm"
+                      />
+                    </div>
+                    <p className="mt-1 text-[10px] uppercase tracking-wider text-gray-500">
+                      {isUpcoming ? "Starts In" : "Ends In"}
+                    </p>
+                  </div>
+                </div>
 
-            <div className="text-center">
-              <Link href={`/tournaments/${data.featuredTournament._id}`}>
-                <Button asChild className="bg-[#01696F] px-8 py-3 text-white hover:bg-[#0C4E54]">
-                  <Trophy className="mr-2 h-5 w-5" />
-                  Enter Tournament
-                </Button>
-              </Link>
-            </div>
-          </div>
-        </section>
+                {/* Featured auction cards */}
+                {data.featuredAuctions.length > 0 && (
+                  <div className="mb-10 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+                    {data.featuredAuctions.map((auction) => (
+                      <Link
+                        key={auction._id}
+                        href={`/auctions/car_view_page/${auction._id}`}
+                        className="group overflow-hidden rounded-xl border border-white/[0.08] bg-[#16181f] transition-colors hover:border-[#01696F]/40"
+                      >
+                        {auction.image && (
+                          <div
+                            className="h-28 bg-cover bg-center transition-transform duration-300 group-hover:scale-105"
+                            style={{
+                              backgroundImage: `url(${auction.image})`,
+                            }}
+                          />
+                        )}
+                        <div className="p-3">
+                          <p className="line-clamp-2 text-xs font-medium text-white">
+                            {auction.title}
+                          </p>
+                          {auction.sort?.price != null && (
+                            <p className="mt-1 font-mono text-xs text-gray-400">
+                              ${auction.sort.price.toLocaleString()}
+                            </p>
+                          )}
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+
+                {/* CTA */}
+                <div className="text-center">
+                  <Link href={`/tournaments/${ft._id}`}>
+                    <Button
+                      asChild
+                      className="bg-[#E94560] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[#E94560]/20 hover:bg-[#E94560]/90"
+                    >
+                      <Trophy className="mr-2 h-5 w-5" />
+                      {isFreePlay ? "Play Free" : isUpcoming ? "Register Now" : "Enter Tournament"}
+                    </Button>
+                  </Link>
+                  <p className="mt-3 text-xs text-gray-500">
+                    {new Date(ft.startTime).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                    {" — "}
+                    {new Date(ft.endTime).toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </p>
+                </div>
+              </div>
+            </section>
+          );
+        })()
       ) : (
         <section className="bg-[#111111] py-16">
           <div className="container mx-auto px-4 text-center">
@@ -604,7 +711,7 @@ export default async function HomePage() {
               {data.trendingAuctions.slice(0, 8).map((auction) => (
                 <Link
                   key={auction._id}
-                  href={`/auctions/${auction._id}`}
+                  href={`/auctions/car_view_page/${auction._id}`}
                   className="group overflow-hidden rounded-xl border border-white/[0.08] bg-[#16181f] transition-colors hover:border-[#01696F]/30"
                 >
                   {auction.image && (


### PR DESCRIPTION
## Summary

Five user-visible tournament bugs, all frontend-only:

- **Homepage trending cards** linked to `/auctions/<id>` (dead route). Fixed to `/auctions/car_view_page/<id>` — stops RSC prefetch 404 console spam.
- **`/api/cars?auction_ids=`** returned `404` on zero matches, blanking tournament detail pages with stale `auction_ids`. Now returns `200 []` with de-duped results across `_id` + `auction_id` lookups.
- **Featured tournament selector** (homepage) picked the next-upcoming tournament by `startTime`, surfacing empty free-play shells as literal "$0 PRIZE POOL". Replaced with engagement-weighted ranking.
- **Featured block** rebuilt: 4-stat hero (Prize/Cars/Players/Timer), "FREE" label when `buyInFee=0` (no literal "$0"), LIVE NOW badge, contextual CTA, clickable auction thumbnails.
- **Tournament detail page** splits auctions into Live (full cards, sorted by urgency) and Ended (compact dimmed row). Compensates for the scraper's -24h deadline offset. Empty-state for ended tournaments with no loadable cars points users at the leaderboard instead of showing "0 cars".

## Test plan

- [ ] Homepage featured tournament no longer shows "$0 PRIZE POOL" for free-play
- [ ] Live NOW badge shows for currently-running tournaments
- [ ] No `/auctions/<ObjectId>` 404s in browser console when hovering trending cards
- [ ] `/tournaments/<id>` for a tournament with expired auctions shows Live + Ended split, not a flat list of expired cars
- [ ] `/tournaments/<id>` for an ended tournament with no resolvable auctions shows "Tournament results below" empty-state, not "0 cars"
- [ ] Stale tournament `auction_ids` no longer blank out the detail page

No changes to scraper or admin repos.

Generated with [Claude Code](https://claude.com/claude-code)
