### PR TITLE
fix: car_view_page resolves by _id — tournament cars no longer 404

### DIFF
--- a/src/app/(pages)/auctions/car_view_page/[id]/page.tsx
+++ b/src/app/(pages)/auctions/car_view_page/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import mongoose from "mongoose";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import Auctions from "@/models/auction.model";
@@ -29,46 +30,27 @@ const USDollar = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 });
 
-const BACKEND_API =
-  process.env.BACKEND_API_URL ?? "https://main.d3bje0ak6q49bm.amplifyapp.com";
-
 // Server-side data fetching
 async function getAuctionData(auctionId: string, userId?: string) {
   try {
-    // 1. Try the direct car lookup endpoint on the backend
+    // Direct DB lookup — supports BOTH MongoDB _id (e.g. from tournament
+    // auction_ids, trending cards, featured lists) AND BaT numeric
+    // auction_id (e.g. from external Twitter links). Previously this page
+    // proxied through an external backend that only knew numeric IDs, so
+    // any caller passing an _id got "Auction Not Found".
+    await connectToDB();
+
     let auction: any = null;
-
-    const directRes = await fetch(
-      `${BACKEND_API}/api/cars?auction_id=${auctionId}`,
-      { cache: "no-store", headers: { Accept: "application/json" } }
-    );
-
-    if (directRes.ok) {
-      const directData = await directRes.json();
-      if (directData && directData._id) {
-        auction = directData;
-      }
+    if (mongoose.isValidObjectId(auctionId)) {
+      auction = await Auctions.findOne({ _id: auctionId }).lean().exec();
     }
-
-    // 2. Fallback: search the filter endpoint (known working)
     if (!auction) {
-      const filterRes = await fetch(
-        `${BACKEND_API}/api/auctions/filter?publicOnly=true&limit=100`,
-        { cache: "no-store", headers: { Accept: "application/json" } }
-      );
-      if (filterRes.ok) {
-        const filterData = await filterRes.json();
-        auction = (filterData.cars ?? []).find(
-          (c: any) => String(c._id) === auctionId
-        ) ?? null;
-      }
+      auction = await Auctions.findOne({ auction_id: auctionId }).lean().exec();
     }
 
     if (!auction || !auction._id) {
       return null;
     }
-
-    await connectToDB();
 
     // User's prediction (if logged in)
     const userPrediction = userId


### PR DESCRIPTION
## Summary

"Auction Not Found" on `/auctions/car_view_page/<id>` for every internal link (tournament cars, trending cards, featured tournament thumbnails, LiveAuctionsSection, wallet transactions, similar-auctions block, etc.).

**Root cause:** the page proxied the auction lookup through an external admin-backend (`main.d3bje0ak6q49bm.amplifyapp.com`) whose `?auction_id=` param only matched BaT numeric IDs. Internal callers pass MongoDB `_id`, so every lookup returned nothing. Meanwhile the same page was already hitting the local DB directly for predictions/stats/similar-auctions — the architecture was split in a way that guaranteed this failure.

**Fix:** drop the external fetch, resolve the auction directly via Mongoose, supporting both `_id` and numeric `auction_id` (same logic as `/api/cars?auction_id=`).

## Repro

1. Open any tournament detail page (e.g., `/tournaments/69e6301b3f806774548f9876`)
2. Click "View Details" on any car
3. Before: "Auction Not Found". After: the auction detail page loads.

Reported case: `/auctions/car_view_page/69e4215196b6295caba215a8`

## Test plan

- [ ] `/auctions/car_view_page/<valid ObjectId>` loads the auction
- [ ] `/auctions/car_view_page/<valid BaT numeric id>` still loads (Twitter link fallback)
- [ ] `/auctions/car_view_page/<nonexistent id>` still shows "Auction Not Found"
- [ ] Predictions, similar auctions, and stats still render (these were already local)

Generated with [Claude Code](https://claude.com/claude-code)
