### PR TITLE
feat(gate): bypass splash for admin/owner roles

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getToken } from "next-auth/jwt";
+import { bypassesGate } from "@/lib/gate";
 
 // Prefixes that always pass through the gate.
 //
@@ -43,7 +44,7 @@ export async function middleware(req: NextRequest) {
     throw new Error("NEXTAUTH_SECRET is required when LAUNCH_GATE_ENABLED is true");
   }
   const token = await getToken({ req, secret });
-  if (token?.isInvited === true) return NextResponse.next();
+  if (bypassesGate(token)) return NextResponse.next();
 
   const url = req.nextUrl.clone();
   url.pathname = "/";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { getAuthSession } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import connectToDB from "@/lib/mongoose";
 import Users from "@/models/user.model";
+import { isRoleBypass } from "@/lib/gate";
 import GatePageClient from "./components/waitlist/GatePageClient";
 
 export const dynamic = "force-dynamic";
@@ -12,8 +13,8 @@ export default async function Home() {
   if (session?.user?.email) {
     await connectToDB();
     const user = await Users.findOne({ email: session.user.email })
-      .lean<{ isInvited?: boolean; referralCode?: string } | null>();
-    if (user?.isInvited) redirect("/app");
+      .lean<{ isInvited?: boolean; role?: string; referralCode?: string } | null>();
+    if (user?.isInvited === true || isRoleBypass(user?.role)) redirect("/app");
     return (
       <GatePageClient
         mode="waitlisted"

--- a/src/app/types/interfaces.ts
+++ b/src/app/types/interfaces.ts
@@ -6,6 +6,8 @@ export interface UserIdName {
 export enum Role {
     USER = "USER",
     AGENT = "AGENT",
+    ADMIN = "ADMIN",
+    OWNER = "OWNER",
 }
 export interface AgentProperties {
     systemInstruction: string;

--- a/src/lib/gate.ts
+++ b/src/lib/gate.ts
@@ -1,0 +1,21 @@
+// Shared gate-bypass predicate. Used by both middleware.ts and the
+// gate page so the rules stay in lockstep.
+//
+// Bypass when EITHER:
+//   - the user is invited (waitlist flow), OR
+//   - the user has an admin/owner role (set by the admin app)
+//
+// Role check is case-insensitive because the codebase mixes lowercase
+// ("admin", "trusted") and uppercase ("USER", "AGENT") values.
+
+const PRIVILEGED_ROLES = new Set(["admin", "owner"]);
+
+export function isRoleBypass(role: unknown): boolean {
+  return typeof role === "string" && PRIVILEGED_ROLES.has(role.toLowerCase());
+}
+
+export function bypassesGate(token: { isInvited?: unknown; role?: unknown } | null | undefined): boolean {
+  if (!token) return false;
+  if (token.isInvited === true) return true;
+  return isRoleBypass(token.role);
+}


### PR DESCRIPTION
## Summary

Users with `role: ADMIN` or `role: OWNER` (case-insensitive) now bypass the launch-gate splash the same way invited users do. Previously only `isInvited === true` got through, which meant admins/owners hit the waitlist screen alongside everyone else.

## Changes

- **`src/lib/gate.ts`** (new) — single `bypassesGate(token)` predicate so middleware and the gate page check the same rule. Plus an `isRoleBypass(role)` helper for the page-level DB lookup.
- **`middleware.ts`** — replaces the inline `token.isInvited === true` check with `bypassesGate(token)`.
- **`src/app/page.tsx`** — also redirects to `/app` when `isRoleBypass(user.role)`, in addition to the existing `isInvited` check.
- **`src/app/types/interfaces.ts`** — `Role` enum extended with `ADMIN` and `OWNER` so the User schema's `enum` validator stops rejecting writes from the admin app.

JWT already includes `role` (set in `auth.ts:262`), so no auth changes needed.

## How to manually approve users

Three working paths (same as before, plus a new role-based one):

1. **Bootstrap-founders endpoint** — sets `isInvited: true` + adds founder badge:
   ```bash
   curl -X POST https://velocity-markets.com/api/admin/bootstrap-founders \
     -H "x-internal-secret: $INTERNAL_API_SECRET" \
     -H "Content-Type: application/json" \
     -d '{"emails":["alice@example.com"]}'
   ```

2. **Direct Mongo** — flip the invited flag:
   ```js
   db.users.updateOne({ email: "x@y.com" }, { $set: { isInvited: true, invitedVia: "direct" } })
   ```

3. **Promote to admin** (new path enabled by this PR):
   ```js
   db.users.updateOne({ email: "x@y.com" }, { $set: { role: "ADMIN" } })
   ```

User must already exist in `users` (sign in once via NextAuth first) for any of these.

## Test plan

- [ ] Set `role: "ADMIN"` on a non-invited user; sign in; verify `/` redirects to `/app`
- [ ] Confirm an unauthenticated visitor still hits the splash
- [ ] Confirm an authed-but-non-invited-non-admin user still hits the waitlisted view
- [ ] Confirm existing invited users still work
- [ ] `role: "admin"` (lowercase) also bypasses (case-insensitive)