### PR TITLE
fix(cron): defensive error handling for tournamentWinner + void-stuck-markets

### DIFF
--- a/src/app/api/cron/void-stuck-markets/route.ts
+++ b/src/app/api/cron/void-stuck-markets/route.ts
@@ -52,6 +52,24 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  // Wrap the entire handler so any throw from clientPromise resolution,
+  // a Mongo query, or downstream logic produces a JSON 500 with a real
+  // detail string — not a generic empty-body 500 from Next.js. Without
+  // this, transient Atlas errors (replica-set election, idle-disconnect)
+  // surface to the cron as opaque 500s that block the workflow.
+  try {
+    return await runVoidStuckMarkets();
+  } catch (err) {
+    console.error("void-stuck-markets: handler threw:", err);
+    const detail = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { ok: false, error: "Internal server error", detail },
+      { status: 500 }
+    );
+  }
+}
+
+async function runVoidStuckMarkets(): Promise<NextResponse> {
   const client = await clientPromise;
   const db = client.db(process.env.DB_NAME || undefined);
   const now = new Date();

--- a/src/app/api/tournamentWinner/route.ts
+++ b/src/app/api/tournamentWinner/route.ts
@@ -426,10 +426,30 @@ export async function GET(req: NextRequest) {
     await mongoSession.commitTransaction();
     return NextResponse.json({ message: 'Tournaments processed successfully' }, { status: 200 });
   } catch (error) {
-    await mongoSession.abortTransaction();
-    console.error('Error in POST API:', error);
-    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+    // Log the original error FIRST so it reaches CloudWatch even if abort
+    // throws below.
+    console.error('Error in tournamentWinner:', error);
+    // Defensive abort: if startTransaction itself failed, there's no
+    // transaction to abort and the driver will throw "no transaction in
+    // progress" — which would escape this catch and produce a generic
+    // empty-body 500 in production.
+    try {
+      if (mongoSession.inTransaction()) {
+        await mongoSession.abortTransaction();
+      }
+    } catch (abortErr) {
+      console.error('tournamentWinner: abortTransaction also failed:', abortErr);
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    return NextResponse.json(
+      { message: 'Internal server error', detail },
+      { status: 500 }
+    );
   } finally {
-    mongoSession.endSession();
+    try {
+      await mongoSession.endSession();
+    } catch (endErr) {
+      console.error('tournamentWinner: endSession failed:', endErr);
+    }
   }
 }


### PR DESCRIPTION
## Summary

Both `/api/tournamentWinner` (Settle Tournaments cron) and `/api/cron/void-stuck-markets` (Void Stuck Markets cron) have been intermittently returning **empty-body 500s** in ~400ms. Workflow logs show bare `Status: 500` with no detail, so the original error never reaches anywhere we can read it.

## Root cause

Two separate bugs, same fix pattern.

**tournamentWinner** — catch block calls `await mongoSession.abortTransaction()` with no guard. When `startTransaction()` itself fails (transient Atlas hiccup, replica-set election, stale cached client), there's no transaction to abort. The driver throws `'no transaction in progress'`. That throw escapes the catch **before** `NextResponse.json` runs, so Next.js returns its own empty-body 500 and the original error never gets logged.

**void-stuck-markets** — the `GET` handler had no top-level try/catch at all. Any throw from `clientPromise` resolution, a Mongo query, or the inner loops escapes to Next.js — same empty-body 500.

## Fix

- **tournamentWinner**: log the original error first, guard `abortTransaction` with `inTransaction()`, wrap it in its own try/catch, return a JSON 500 with `err.message` as `detail`, guard `endSession` in finally.
- **void-stuck-markets**: extract body to a private `runVoidStuckMarkets()` and wrap the call in a try/catch that returns a JSON 500 with `detail`.

Both routes already had idempotent semantics (OPEN guards, isActive updates that no-op on re-run), so this is purely about making failures observable. Behaviour on success is unchanged.

## Diagnostic data backing the hypothesis

- Failed runs return in **~400ms**, successful runs in **~450ms** — same speed, rules out timeout/cold-start
- Mongo currently has 0 stuck tournaments (`isActive:true AND endTime < now`) → archive logic at the top of the route runs cleanly
- Both legacy code paths (`status:1`, `status:2`) iterate zero times → the failure is at session/transaction setup, not deep into the loops
- void-stuck-markets has no transaction wrapper → the only way it can 500 fast with empty body is an unhandled throw at the function boundary

## Test plan

- [ ] After deploy, watch the next `Settle Tournaments` cron run — failures (if any) should now return JSON `{message, detail}` so the workflow log shows the real error
- [ ] Same for `Void Stuck Markets`
- [ ] Successful runs still return their existing `{ok: true, ...}` / `{message: 'Tournaments processed successfully'}` shapes — no behaviour change on the happy path
- [ ] If the transient-Atlas hypothesis is right, failure rate should drop because Atlas blips usually resolve before the next 6h run anyway. If failures persist, the response body now tells us why.