### PR TITLE
fix(tournaments): default to 'newest' on Completed tab

### DIFF
--- a/src/app/(pages)/tournaments/page.tsx
+++ b/src/app/(pages)/tournaments/page.tsx
@@ -52,6 +52,9 @@ export default function TournamentsPage() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [sortBy, setSortBy] = useState<SortOption>('ending_soon');
+  // Once the user picks a sort manually, stop auto-flipping it when the
+  // status tab changes — they overrode the default and we should respect it.
+  const [hasManualSort, setHasManualSort] = useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState<string>('');
 
   // Ladder
@@ -146,6 +149,15 @@ export default function TournamentsPage() {
       .catch(() => {})
       .finally(() => setLadderLoading(false));
   }, []);
+
+  // Default sort follows the active tab so users don't see ancient
+  // tournaments at the top of the Completed view: completed → newest first,
+  // everything else → ending soonest. Once the user picks a sort manually,
+  // hasManualSort latches and we stop auto-flipping.
+  useEffect(() => {
+    if (hasManualSort) return;
+    setSortBy(statusFilter === 'completed' ? 'newest' : 'ending_soon');
+  }, [statusFilter, hasManualSort]);
 
   // Apply filters and sorting
   useEffect(() => {
@@ -375,7 +387,10 @@ export default function TournamentsPage() {
             <label className="mb-2 block text-sm text-gray-400">Sort By</label>
             <select
               value={sortBy}
-              onChange={(e) => setSortBy(e.target.value as SortOption)}
+              onChange={(e) => {
+                setHasManualSort(true);
+                setSortBy(e.target.value as SortOption);
+              }}
               className="w-full rounded-md border border-white/[0.08] bg-[#16181f] p-2 text-white"
             >
               <option value="ending_soon">Ending Soon</option>


### PR DESCRIPTION
## Summary

The `/tournaments` page defaulted to `sortBy='ending_soon'` regardless of which status tab was active. On the **Completed** tab that means ascending `endTime` — oldest expired tournaments at the top, which is what was driving the "showing all old tournaments" symptom.

## Fix

Auto-flip the default sort based on `statusFilter`:
- `completed` → `newest` (most-recently-ended first)
- `active` / `upcoming` / `all` → `ending_soon` (urgency cue, unchanged)

Once the user picks a sort from the dropdown, a `hasManualSort` flag latches and the auto-flip stops — so we don't clobber intentional choices when they switch between tabs.

## Why not just default everything to 'newest'

For active/upcoming tournaments, "ending soon" is genuinely useful — it tells you which to enter before they close. "Newest" doesn't convey urgency. Context-dependent default keeps both views useful.

## Test plan

- [ ] Land on /tournaments — see active tournaments sorted by ending soonest (default behaviour preserved)
- [ ] Click "Completed" tab — list reorders to newest endings first (was: oldest first)
- [ ] Manually pick "Prize Pool" from the Sort dropdown — switch tabs — sort stays on Prize Pool (manual override respected)