### PR TITLE
feat(price_is_right): drawer follow-ups — truncation hint, tablist thumbs, e2e gate

### DIFF
--- a/e2e/guess-the-hammer-drawer.spec.ts
+++ b/e2e/guess-the-hammer-drawer.spec.ts
@@ -7,10 +7,20 @@ test.describe("guess the hammer — details drawer", () => {
   }) => {
     await page.goto("/price_is_right");
 
-    // Wait for the first card with a Details button to appear. If the page
-    // requires auth or returns no auctions in this environment, skip.
+    // Wait for the first card with a Details button to appear. When run
+    // against a seeded environment (E2E_HAS_DATA=1), require auctions to be
+    // present and fail loudly if they aren't — otherwise this spec silently
+    // green-skips in CI and rubber-stamps real regressions. In local dev or
+    // anywhere without a seed, allow the skip.
     const detailsButton = page.getByRole("button", { name: /^view details/i }).first();
-    if ((await detailsButton.count()) === 0) {
+    const detailsCount = await detailsButton.count();
+    if (detailsCount === 0) {
+      const requireData = process.env.E2E_HAS_DATA === "1";
+      if (requireData) {
+        throw new Error(
+          "E2E_HAS_DATA=1 but no auctions render on /price_is_right — seed required",
+        );
+      }
       test.skip(true, "No auctions on the page in this env");
     }
 

--- a/src/app/(pages)/price_is_right/page.tsx
+++ b/src/app/(pages)/price_is_right/page.tsx
@@ -221,6 +221,8 @@ async function getPageData() {
             description: Array.isArray(a.description)
               ? a.description.slice(0, 8)
               : a.description,
+            descriptionTruncated:
+              Array.isArray(a.description) && a.description.length > 8,
             listing_details: a.listing_details,
             page_url: a.page_url,
             sort: a.sort,

--- a/src/app/components/price_is_right/AuctionDetailsDrawer.tsx
+++ b/src/app/components/price_is_right/AuctionDetailsDrawer.tsx
@@ -1,7 +1,7 @@
 // src/app/components/price_is_right/AuctionDetailsDrawer.tsx
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { ExternalLink, Info } from "lucide-react";
@@ -262,6 +262,25 @@ function Gallery({ images, altBase }: { images: Array<{ src: string }>; altBase:
   const [index, setIndex] = useState(0);
   const safeIndex = Math.min(Math.max(0, index), images.length - 1);
   const primary = images[safeIndex];
+  const tablistRef = useRef<HTMLDivElement | null>(null);
+
+  // ARIA tablist keyboard pattern: arrow keys cycle, Home/End jump to ends,
+  // single tab stop on the active thumb (roving tabIndex). Auto-activates
+  // on focus to mirror the click behaviour.
+  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    let next = safeIndex;
+    if (e.key === "ArrowLeft") next = (safeIndex - 1 + images.length) % images.length;
+    else if (e.key === "ArrowRight") next = (safeIndex + 1) % images.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = images.length - 1;
+    else return;
+    e.preventDefault();
+    setIndex(next);
+    const tabs = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    tabs?.[next]?.focus();
+    tabs?.[next]?.scrollIntoView({ inline: "nearest", block: "nearest" });
+  }
+
   return (
     <div>
       <div className="relative aspect-[16/9] bg-[#13202D]">
@@ -274,29 +293,40 @@ function Gallery({ images, altBase }: { images: Array<{ src: string }>; altBase:
         />
       </div>
       {images.length > 1 ? (
-        <div className="px-5 py-3 flex gap-2 overflow-x-auto">
-          {images.map((img, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() => setIndex(i)}
-              aria-label={`Show photo ${i + 1} of ${images.length}`}
-              aria-current={i === safeIndex}
-              className={`relative shrink-0 w-16 h-12 rounded overflow-hidden border ${
-                i === safeIndex
-                  ? "border-[#E94560]"
-                  : "border-white/[0.08] hover:border-white/[0.2]"
-              } transition`}
-            >
-              <Image
-                src={img.src}
-                alt=""
-                fill
-                sizes="64px"
-                className="object-cover"
-              />
-            </button>
-          ))}
+        <div
+          ref={tablistRef}
+          role="tablist"
+          aria-label="Auction photo gallery"
+          onKeyDown={handleKeyDown}
+          className="px-5 py-3 flex gap-2 overflow-x-auto"
+        >
+          {images.map((img, i) => {
+            const active = i === safeIndex;
+            return (
+              <button
+                key={i}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                aria-label={`Show photo ${i + 1} of ${images.length}`}
+                tabIndex={active ? 0 : -1}
+                onClick={() => setIndex(i)}
+                className={`relative shrink-0 w-16 h-12 rounded overflow-hidden border ${
+                  active
+                    ? "border-[#E94560]"
+                    : "border-white/[0.08] hover:border-white/[0.2]"
+                } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#E94560] transition`}
+              >
+                <Image
+                  src={img.src}
+                  alt=""
+                  fill
+                  sizes="64px"
+                  className="object-cover"
+                />
+              </button>
+            );
+          })}
         </div>
       ) : null}
     </div>

--- a/src/app/components/price_is_right/AuctionDetailsDrawer.tsx
+++ b/src/app/components/price_is_right/AuctionDetailsDrawer.tsx
@@ -57,6 +57,12 @@ export default function AuctionDetailsDrawer({
   const lot = getLot(auction);
   const highlights = getHighlights(auction);
   const descriptionBlocks = getDescriptionBlocks(auction);
+  // Source description had more blocks than we forwarded — drawer should
+  // surface a hint pointing to the full BaT page so the "Read more" toggle
+  // doesn't lie about reaching the end. Set server-side in
+  // /price_is_right/page.tsx when description.length > 8.
+  const descriptionTruncated =
+    "descriptionTruncated" in auction && auction.descriptionTruncated === true;
   const batUrl = getBaTUrl(auction);
   const status = getAuctionStatus(auction);
   const fullPageId =
@@ -166,17 +172,29 @@ export default function AuctionDetailsDrawer({
                   )
                 )}
               </div>
-              {descriptionBlocks.length > DESCRIPTION_PREVIEW_BLOCKS ? (
-                <button
-                  type="button"
-                  onClick={() => setDescriptionExpanded((v) => !v)}
-                  aria-expanded={descriptionExpanded}
-                  aria-controls="auction-drawer-description-content"
-                  className="mt-2 text-xs text-[#E94560] hover:underline focus-visible:underline focus-visible:outline-none"
-                >
-                  {descriptionExpanded ? "Read less" : "Read more"}
-                </button>
-              ) : null}
+              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+                {descriptionBlocks.length > DESCRIPTION_PREVIEW_BLOCKS ? (
+                  <button
+                    type="button"
+                    onClick={() => setDescriptionExpanded((v) => !v)}
+                    aria-expanded={descriptionExpanded}
+                    aria-controls="auction-drawer-description-content"
+                    className="text-xs text-[#E94560] hover:underline focus-visible:underline focus-visible:outline-none"
+                  >
+                    {descriptionExpanded ? "Read less" : "Read more"}
+                  </button>
+                ) : null}
+                {descriptionTruncated && batUrl ? (
+                  <a
+                    href={batUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-gray-400 hover:text-white focus-visible:underline focus-visible:outline-none"
+                  >
+                    Full description on Bring a Trailer ↗
+                  </a>
+                ) : null}
+              </div>
             </section>
           ) : null}
 


### PR DESCRIPTION
## Summary

Three follow-ups from the final review of PR #354 (auction details drawer):

1. **Description-truncation hint.** When the source description has more than 8 blocks the page projection caps it; the drawer now exposes a 'Full description on Bring a Trailer ↗' link beside Read-more so the toggle isn't dishonest about reaching the end. Server adds `descriptionTruncated: boolean` next to `description`; drawer reads it via property check.
2. **E2E skip is gated.** `e2e/guess-the-hammer-drawer.spec.ts` previously `test.skip(true, ...)`-ed silently in any environment without auctions, which means CI green-rubber-stamps real regressions. Now: when `E2E_HAS_DATA=1` is set we throw on missing auctions; otherwise the skip remains for local-dev convenience.
3. **Thumb strip is a real ARIA tablist.** Wrapper `role="tablist"` + roving `tabIndex` + arrow keys / Home / End keyboard cycling, with `aria-selected` and focus-visible ring on the active tab. Replaces the previous all-tabbable buttons-with-aria-current pattern.

## Files changed

- `src/app/(pages)/price_is_right/page.tsx` — emit `descriptionTruncated`
- `src/app/components/price_is_right/AuctionDetailsDrawer.tsx` — render hint; tablist Gallery
- `e2e/guess-the-hammer-drawer.spec.ts` — gated skip

## Test plan

- [ ] Drawer with a description shorter than 8 blocks: no hint, Read-more behaves as before.
- [ ] Drawer with a description longer than 8 blocks: hint appears, links to BaT `page_url`.
- [ ] Drawer thumb strip: Tab moves into the active thumb, ArrowLeft/Right cycle (with wrap), Home/End jump to ends. Focus-visible ring shows on the active thumb.
- [ ] `E2E_HAS_DATA=1 npx playwright test e2e/guess-the-hammer-drawer.spec.ts` against an empty page → fails with seed error.
- [ ] Bare `npx playwright test e2e/guess-the-hammer-drawer.spec.ts` against an empty page → skips cleanly.

## Out of scope

Item #4 from the final-review followup list (refactor existing guess modal to a Radix Dialog) ships as a separate PR.