### PR TITLE
fix(mongo): bump serverSelectionTimeoutMS 5s -> 15s

### DIFF
--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -9,7 +9,11 @@ if (!uri) {
 
 const options: MongoClientOptions = {
   maxPoolSize: 5,               // Match Mongoose — keep small for Atlas shared tier
-  serverSelectionTimeoutMS: 5000,
+  // Atlas shared-tier clusters can pause when idle and replica-set elections
+  // can briefly outlast the default. 5s was tight enough to throw on every
+  // cold start; 15s leaves comfortable headroom under the 30s Lambda budget
+  // while the cron's own per-run TIME_BUDGET (22s) still bounds total work.
+  serverSelectionTimeoutMS: 15000,
   socketTimeoutMS: 30000,
 };
 

--- a/src/lib/mongoose.ts
+++ b/src/lib/mongoose.ts
@@ -32,7 +32,10 @@ const connectToDB = async () => {
     const opts: mongoose.ConnectOptions = {
       ...(dbName ? { dbName } : {}),
       maxPoolSize: 5,       // Keep pool small — M0 free tier has a 500 connection cap
-      serverSelectionTimeoutMS: 5000,
+      // Bumped from 5s — Atlas shared-tier idle pauses + replica-set elections
+      // routinely exceed 5s on cold starts, surfacing as cron 500s with
+      // "Server selection timed out". 15s leaves headroom under Lambda's 30s.
+      serverSelectionTimeoutMS: 15000,
       socketTimeoutMS: 30000,
     };
 


### PR DESCRIPTION
## Summary

PR #352's defensive error handling did its job — the latest `Void Stuck Markets` failure now returns a real error in the workflow log:

```
Status: 500
Response: {"ok":false,"error":"Internal server error","detail":"Server selection timed out after 5000 ms"}
```

That's the MongoDB driver's `serverSelectionTimeoutMS: 5000` set in `src/lib/mongodb.ts` (and same in `src/lib/mongoose.ts`). Atlas's shared-tier behavior — idle pauses + replica-set elections — routinely exceeds 5s on cold-start runs. The driver bails before the connection becomes usable; the cron sees a fast 500 and the original write never lands.

## Fix

Bump both connection configs from 5s → 15s. 15s leaves comfortable headroom for failover while staying well under Lambda's 30s budget and each cron's 22s `TIME_BUDGET`. Both `mongodb.ts` (raw client used by the OG route, void-stuck-markets, share unfurl, bootstrap-founders, etc.) and `mongoose.ts` (used everywhere model-based) bumped together so all callers benefit.

## Why this is the right fix

- **Confirms the original hypothesis from PR #352:** intermittent failures correlate with Atlas connection turbulence, not application logic. The defensive handler made that visible.
- **Low blast radius:** the only behavior change is 'wait longer before declaring the cluster dead.' Successful warm-cluster requests are byte-identical.
- **Doesn't add retry complexity:** the driver already has built-in retryable-write/read semantics. The bug was just the giving-up threshold.

## Test plan

- [ ] Wait for next `Void Stuck Markets` cron run (every 6h). Should succeed, OR if it still fails, the response body now reveals a different root cause.
- [ ] Same for `Settle Tournaments` (also benefits from the bump).
- [ ] Cold-start runs (early UTC mornings) — no more 5s timeouts.