### PR TITLE
chore(diag): expose LAUNCH_GATE_ENABLED at runtime to find why gate isn't firing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -25,10 +25,19 @@ const ALLOW_PREFIXES = [
   "/terms_of_service",
 ];
 
-const LAUNCH_GATE_ENABLED = /^(1|true|on|yes)$/i.test(process.env.LAUNCH_GATE_ENABLED ?? "");
+const RAW_GATE_ENV = process.env.LAUNCH_GATE_ENABLED ?? "";
+const LAUNCH_GATE_ENABLED = /^(1|true|on|yes)$/i.test(RAW_GATE_ENV);
+
+function diag(res: NextResponse) {
+  res.headers.set("x-gate-mw", "1");
+  res.headers.set("x-gate-enabled", String(LAUNCH_GATE_ENABLED));
+  res.headers.set("x-gate-raw-len", String(RAW_GATE_ENV.length));
+  res.headers.set("x-gate-raw-first", RAW_GATE_ENV.slice(0, 1));
+  return res;
+}
 
 export async function middleware(req: NextRequest) {
-  if (!LAUNCH_GATE_ENABLED) return NextResponse.next();
+  if (!LAUNCH_GATE_ENABLED) return diag(NextResponse.next());
 
   const { pathname } = req.nextUrl;
   if (pathname === "/") return NextResponse.next();
@@ -44,11 +53,11 @@ export async function middleware(req: NextRequest) {
     throw new Error("NEXTAUTH_SECRET is required when LAUNCH_GATE_ENABLED is true");
   }
   const token = await getToken({ req, secret });
-  if (bypassesGate(token)) return NextResponse.next();
+  if (bypassesGate(token)) return diag(NextResponse.next());
 
   const url = req.nextUrl.clone();
   url.pathname = "/";
-  return NextResponse.rewrite(url);
+  return diag(NextResponse.rewrite(url));
 }
 
 export const config = {

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -14,6 +14,9 @@ export async function GET() {
       NEXTAUTH_URL: !!process.env.NEXTAUTH_URL,
       NEXTAUTH_SECRET: !!process.env.NEXTAUTH_SECRET,
       GOOGLE_CLIENT_ID: !!process.env.GOOGLE_CLIENT_ID,
+      LAUNCH_GATE_ENABLED_value: process.env.LAUNCH_GATE_ENABLED ?? null,
+      LAUNCH_GATE_ENABLED_length: (process.env.LAUNCH_GATE_ENABLED ?? "").length,
+      LAUNCH_GATE_ENABLED_regex_match: /^(1|true|on|yes)$/i.test(process.env.LAUNCH_GATE_ENABLED ?? ""),
     },
     env_keys: Object.keys(process.env)
       .filter(k => !k.includes('SECRET') && !k.includes('PASSWORD') && !k.includes('KEY'))


### PR DESCRIPTION
## Summary
Diagnostic-only PR. Helps figure out why the launch gate isn't enforcing in prod despite `LAUNCH_GATE_ENABLED=true` being set in Amplify.

Adds:
- `x-gate-mw`, `x-gate-enabled`, `x-gate-raw-len`, `x-gate-raw-first` response headers from middleware (proves whether middleware is running and what it sees).
- `LAUNCH_GATE_ENABLED_value`, `_length`, `_regex_match` fields in `/api/health` (proves what the page Lambda sees).

No behavior change. Will revert immediately after diagnosis.
