### PR TITLE
feat(admin): /admin/invite — grant gate access without secrets

### DIFF
--- a/src/app/admin/invite/InviteForm.tsx
+++ b/src/app/admin/invite/InviteForm.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+
+type Result =
+  | { ok: true; email: string; referralCode?: string; already_invited?: boolean }
+  | { ok: false; error: string };
+
+export default function InviteForm() {
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<Result | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setResult(null);
+    try {
+      const res = await fetch("/api/admin/invite", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (res.ok && data.ok) {
+        setResult({
+          ok: true,
+          email: data.email,
+          referralCode: data.referralCode,
+          already_invited: !!data.already_invited,
+        });
+        setEmail("");
+      } else {
+        setResult({ ok: false, error: data.error ?? `HTTP ${res.status}` });
+      }
+    } catch (err) {
+      setResult({ ok: false, error: (err as Error).message });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <label className="text-sm text-gray-300">Email</label>
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="user@example.com"
+          autoComplete="off"
+          className="w-full rounded-md bg-[#13202D] border border-[#1E2A36] px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-[#E94560]"
+        />
+        <button
+          type="submit"
+          disabled={busy || !email}
+          className="rounded-md bg-[#E94560] px-4 py-2 font-semibold text-white disabled:opacity-50"
+        >
+          {busy ? "Inviting…" : "Grant invite"}
+        </button>
+      </form>
+
+      {result && (
+        <div
+          className={`mt-4 rounded-md border px-3 py-2 text-sm ${
+            result.ok
+              ? "border-[#00D4AA] text-[#00D4AA]"
+              : "border-[#E94560] text-[#E94560]"
+          }`}
+        >
+          {result.ok ? (
+            <>
+              {result.already_invited
+                ? `${result.email} was already invited.`
+                : `Invited ${result.email}.`}{" "}
+              {result.referralCode && (
+                <span className="text-gray-300">
+                  Referral code: <code>{result.referralCode}</code>
+                </span>
+              )}
+            </>
+          ) : (
+            <>Error: {result.error}</>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/admin/invite/page.tsx
+++ b/src/app/admin/invite/page.tsx
@@ -1,0 +1,27 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { isRoleBypass } from "@/lib/gate";
+import InviteForm from "./InviteForm";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminInvitePage() {
+  const session = (await getServerSession(authOptions)) as
+    | { user?: { role?: string } }
+    | null;
+  if (!isRoleBypass(session?.user?.role)) redirect("/");
+
+  return (
+    <main className="min-h-screen bg-[#0A0A1A] text-white px-4 py-12">
+      <div className="max-w-md mx-auto">
+        <h1 className="text-2xl font-bold mb-2">Invite a user past the gate</h1>
+        <p className="text-sm text-gray-400 mb-6">
+          Sets <code>isInvited: true</code> on the user with the given email.
+          The user must already have signed up (we lookup by email).
+        </p>
+        <InviteForm />
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/admin/invite/route.ts
+++ b/src/app/api/admin/invite/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import connectToDB from "@/lib/mongoose";
+import Users from "@/models/user.model";
+import { isRoleBypass } from "@/lib/gate";
+import { generateReferralCode } from "@/lib/waitlist/codes";
+
+export const dynamic = "force-dynamic";
+
+interface RequestUser {
+  role?: string;
+  email?: string;
+  isInvited?: boolean;
+  referralCode?: string;
+}
+
+export async function POST(req: Request) {
+  const session = (await getServerSession(authOptions)) as
+    | { user?: RequestUser }
+    | null;
+  if (!isRoleBypass(session?.user?.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as { email?: unknown };
+  const email =
+    typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+  }
+
+  await connectToDB();
+  const user = await Users.findOne({ email }).lean<RequestUser & {
+    _id: unknown;
+  } | null>();
+  if (!user) {
+    return NextResponse.json(
+      { error: "User not found — they must sign up first" },
+      { status: 404 }
+    );
+  }
+
+  if (user.isInvited === true) {
+    return NextResponse.json({
+      ok: true,
+      already_invited: true,
+      email,
+      referralCode: user.referralCode,
+    });
+  }
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const code = user.referralCode ?? generateReferralCode();
+    try {
+      await Users.updateOne(
+        { _id: user._id },
+        {
+          $set: {
+            isInvited: true,
+            invitedVia: "direct",
+            referralCode: code,
+          },
+        }
+      );
+      return NextResponse.json({ ok: true, email, referralCode: code });
+    } catch (err) {
+      const e = err as { code?: number; keyPattern?: Record<string, unknown> };
+      if (e.code !== 11000 || !e.keyPattern || !("referralCode" in e.keyPattern)) {
+        throw err;
+      }
+    }
+  }
+  return NextResponse.json(
+    { error: "Referral code collision retries exhausted" },
+    { status: 500 }
+  );
+}


### PR DESCRIPTION
## Summary
Adds `/admin/invite` — an admin-only page to grant gate access to a user by email. No secret required (uses session role).

- `POST /api/admin/invite { email }` — sets `isInvited:true`, `invitedVia:"direct"`, fills `referralCode` if missing. Returns 403 unless session passes `isRoleBypass` (admin/owner).
- `/admin/invite` page — server-component role guard, simple client form, returns the new referral code.
- Idempotent: replay returns `{ ok:true, already_invited:true }`.
- 404 if user hasn't signed up — they must hit the cold gate first so a User doc exists.

## Why
We needed a fast way to whitelist beta testers without pulling `INTERNAL_API_SECRET` from Amplify each time. Lighter than `bootstrap-founders`: no founder badge, no `invitedVia:"founding"` — just enough to pass `gateOrPass()`.

## Test plan
After deploy, log in as admin/owner, visit `/admin/invite`, enter `exitspeed01@gmail.com`, submit. Should return `{ ok, referralCode: "..." }`. Verify they can reach `/tournaments` after re-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
