### PR TITLE
fix(predictions): unify cutoff to 1h + clarify wording

### DIFF
--- a/src/app/(pages)/auctions/car_view_page/[id]/page.tsx
+++ b/src/app/(pages)/auctions/car_view_page/[id]/page.tsx
@@ -378,7 +378,7 @@ export default async function AuctionDetailPage({ params }: { params: Promise<{ 
                 <div className="text-center">
                   <Clock className="mx-auto mb-3 h-12 w-12 text-gray-400" />
                   <p className="text-gray-400">
-                    {hasEnded ? 'This auction has ended' : 'Predictions locked (less than 1 hour remaining)'}
+                    {hasEnded ? 'This auction has ended' : 'Predictions locked — auction ends in less than 1 hour'}
                   </p>
                 </div>
               ) : !session ? (

--- a/src/app/(pages)/tournaments/[tournament_id]/page.tsx
+++ b/src/app/(pages)/tournaments/[tournament_id]/page.tsx
@@ -196,11 +196,11 @@ export default function TournamentDetailPage() {
         setAuctions(validAuctions);
 
         // Initialize prediction inputs. Scraper writes sort.deadline 24h
-        // early, so real end = deadline + 24h. Predictions close 5 minutes
+        // early, so real end = deadline + 24h. Predictions close 1 hour
         // before that real end. These constants MUST match the ones used in
         // the render block or the two panels will disagree.
         const DAY_MS = 24 * 60 * 60 * 1000;
-        const PREDICTION_BUFFER_MS = 5 * 60 * 1000;
+        const PREDICTION_BUFFER_MS = 60 * 60 * 1000;
         const now = Date.now();
         setPredictions(
           validAuctions.map((auction: Auction) => {
@@ -480,7 +480,7 @@ export default function TournamentDetailPage() {
   // the stale scraper timestamp. Predictions close PREDICTION_BUFFER_MS
   // before the real end to avoid last-second races.
   const DAY_MS = 24 * 60 * 60 * 1000;
-  const PREDICTION_BUFFER_MS = 5 * 60 * 1000;
+  const PREDICTION_BUFFER_MS = 60 * 60 * 1000;
   const auctionRealEnd = (a: Auction): number => {
     const raw = a.sort?.deadline;
     if (!raw) return 0;
@@ -674,7 +674,7 @@ export default function TournamentDetailPage() {
             <p className="text-sm text-[#FFB547]">
               <strong>Important:</strong> You must predict all {liveAuctions.length}{" "}
               open {liveAuctions.length === 1 ? "auction" : "auctions"} to qualify for prizes.
-              Each auction closes to new predictions 5 minutes before its hammer time.
+              Predictions lock 1 hour before each auction ends.
               {endedAuctions.length > 0 && (
                 <>
                   {" "}
@@ -726,7 +726,7 @@ export default function TournamentDetailPage() {
                   {liveAuctions.length !== auctions.length && (
                     <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-[#00D4AA]">
                       <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#00D4AA]" />
-                      Open for predictions · closes 5 min before hammer
+                      Open for predictions · locks 1 hour before each auction ends
                     </div>
                   )}
                   <div className="space-y-6">

--- a/src/app/components/PredictionFormClient.tsx
+++ b/src/app/components/PredictionFormClient.tsx
@@ -200,7 +200,7 @@ export default function PredictionFormClient({
             </Link>
 
             <p className="text-center text-xs text-gray-500">
-              Predictions lock 1 hour before auction end
+              Predictions lock 1 hour before each auction ends
             </p>
           </form>
         )}
@@ -270,7 +270,7 @@ export default function PredictionFormClient({
       </Button>
 
       <p className="text-center text-xs text-gray-500">
-        Predictions lock 1 hour before auction end
+        Predictions lock 1 hour before each auction ends
       </p>
     </form>
   );


### PR DESCRIPTION
## Summary
Beta tester (exitspeed01) flagged two pages disagreeing on the prediction cutoff: tournaments said **5 min** before hammer, auction detail / prediction form said **1 hour** before end. This unifies on **1 hour** and uses one canonical phrase everywhere.

> Canonical: **"Predictions lock 1 hour before each auction ends."**

## Changes
- `tournaments/[tournament_id]/page.tsx` — `PREDICTION_BUFFER_MS` `5 min` → `1 hour` (both occurrences; the existing comment notes both panels MUST agree).
- `tournaments/[tournament_id]/page.tsx` — UI copy unified in joiner warning + live-section header.
- `auctions/car_view_page/[id]/page.tsx` — locked-state copy rephrased for clarity.
- `PredictionFormClient.tsx` — hint copy unified.

## Caveat (out of scope, follow-up needed)
There's still **no server-side enforcement** in `POST /api/predictions` — the lock is UI-only. A determined caller could submit past the cutoff. Hardening that is a separate task.

## Test plan
- [ ] `/tournaments/<id>` shows "Predictions lock 1 hour before each auction ends" in joiner warning + live section header
- [ ] An auction with <60min remaining displays the locked state on `/auctions/car_view_page/<id>`
- [ ] Prediction form footer text matches the canonical phrase
- [ ] No "5 min" cutoff text anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
