### PR TITLE
fix(predictions): server-side enforcement of 1h cutoff

### DIFF
--- a/src/app/api/predictions/route.tsx
+++ b/src/app/api/predictions/route.tsx
@@ -1,8 +1,16 @@
 import connectToDB from "@/lib/mongoose";
 import { Predictions } from "@/models/predictions.model";
+import Auctions from "@/models/auction.model";
 import { NextRequest, NextResponse } from "next/server";
 import { getAuthSession } from "@/lib/auth";
 import { Types } from "mongoose";
+
+// Predictions lock 1 hour before each auction ends. Scraper writes
+// sort.deadline 24h early, so real end = sort.deadline + 24h. Mirrors the
+// client constants in src/app/(pages)/tournaments/[tournament_id]/page.tsx
+// and src/app/(pages)/auctions/car_view_page/[id]/page.tsx.
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PREDICTION_BUFFER_MS = 60 * 60 * 1000;
 
 export const dynamic = "force-dynamic";
 
@@ -70,6 +78,34 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json();
     await connectToDB();
+
+    // Enforce the 1h-before-end cutoff server-side. UI also blocks this,
+    // but the lock can't live only in the client.
+    const auctionId = typeof body?.auction_id === "string" ? body.auction_id : null;
+    if (!auctionId || !Types.ObjectId.isValid(auctionId)) {
+      return NextResponse.json({ message: "Invalid auction_id" }, { status: 400 });
+    }
+    const auction = await Auctions.findById(auctionId)
+      .select("sort.deadline")
+      .lean<{ sort?: { deadline?: Date | string } } | null>();
+    if (!auction) {
+      return NextResponse.json({ message: "Auction not found" }, { status: 404 });
+    }
+    const rawDeadline = auction.sort?.deadline;
+    if (!rawDeadline) {
+      return NextResponse.json(
+        { message: "Auction has no deadline; predictions disabled" },
+        { status: 409 }
+      );
+    }
+    const realEnd = new Date(rawDeadline).getTime() + DAY_MS;
+    const closeAt = realEnd - PREDICTION_BUFFER_MS;
+    if (Date.now() >= closeAt) {
+      return NextResponse.json(
+        { message: "Predictions are locked for this auction" },
+        { status: 409 }
+      );
+    }
 
     // Always derive user identity from the verified session — never trust client payload.
     const newPrediction = await Predictions.create({


### PR DESCRIPTION
## Summary
Server-side enforcement of the 1-hour prediction cutoff. Companion to #364 (which unified the UI text).

`POST /api/predictions` now validates against `sort.deadline + 24h - 1h` (the same formula used client-side) and rejects late submissions with HTTP 409. Without this, the lock was UI-only — anyone with `curl` could post a prediction past the cutoff.

## Behavior
- **400** — `auction_id` missing or not a valid ObjectId
- **404** — auction not found
- **409** — auction has no `sort.deadline` (predictions disabled)
- **409** — predictions are locked (less than 1 hour to end)
- **201** — created (unchanged happy path)

## Test plan
- [ ] POST with valid auction >1h from end → 201
- [ ] POST with valid auction <1h from end → 409 "Predictions are locked"
- [ ] POST with bogus `auction_id` → 400
- [ ] POST with missing auction → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
