### PR TITLE
fix(mongo): self-healing MongoClient cache — stops stale-socket 500s

### DIFF
--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -17,25 +17,89 @@ const options: MongoClientOptions = {
   socketTimeoutMS: 30000,
 };
 
-// Cache across serverless invocations via global (same pattern as mongoose.ts)
+// Cache the connect-promise across serverless invocations. The previous
+// version cached forever, so when Atlas closed the socket (idle pause /
+// replica-set failover), the cached promise still resolved to a dead client
+// and the next request blew up with "connection N to <ip>:27017 closed".
+//
+// Self-healing now:
+//   - Listeners on the underlying MongoClient null the cache on close/topology-
+//     close so a future request rebuilds instead of reusing a corpse.
+//   - The default export is a thenable that re-checks the cache on every
+//     `await`. Callers keep the existing `const client = await clientPromise`
+//     ergonomics; no callsite changes needed across the 52 importers.
+//   - Health is also verified with a cheap admin ping when a cached client
+//     looks alive but might be wedged (covers the race where the close event
+//     hasn't fired but the socket is already half-open).
 declare global {
   // eslint-disable-next-line no-var
   var _mongoClientPromise: Promise<MongoClient> | undefined;
 }
 
-let clientPromise: Promise<MongoClient>;
-
-if (!uri) {
-  clientPromise = Promise.reject(
-    new Error('Invalid/Missing environment variable: "MONGODB_URI"')
-  );
-} else if (!global._mongoClientPromise) {
-  const client = new MongoClient(uri, options);
-  global._mongoClientPromise = client.connect();
-  console.log(`✅ MongoClient connected (pool ≤5)`);
-  clientPromise = global._mongoClientPromise;
-} else {
-  clientPromise = global._mongoClientPromise;
+function invalidate(reason: string): void {
+  if (global._mongoClientPromise) {
+    console.warn(`⚠️ MongoClient cache invalidated (${reason})`);
+  }
+  global._mongoClientPromise = undefined;
 }
 
-export default clientPromise;
+async function pingClient(client: MongoClient): Promise<boolean> {
+  try {
+    await client.db('admin').command({ ping: 1 });
+    return true;
+  } catch (err) {
+    console.warn('⚠️ MongoClient ping failed:', (err as Error).message);
+    return false;
+  }
+}
+
+async function getActiveClient(): Promise<MongoClient> {
+  if (!uri) {
+    throw new Error('Invalid/Missing environment variable: "MONGODB_URI"');
+  }
+
+  // Hot path: existing cached promise. Verify health before handing it back.
+  if (global._mongoClientPromise) {
+    try {
+      const cached = await global._mongoClientPromise;
+      if (await pingClient(cached)) {
+        return cached;
+      }
+      invalidate('ping failed');
+    } catch (err) {
+      invalidate(`cached promise rejected: ${(err as Error).message}`);
+    }
+  }
+
+  // Cold path: build a fresh client and attach self-heal listeners.
+  const client = new MongoClient(uri, options);
+  client.on('close', () => invalidate('close event'));
+  client.on('topologyClosed', () => invalidate('topologyClosed event'));
+  client.on('error', (err: Error) => {
+    console.warn('⚠️ MongoClient error event:', err.message);
+    invalidate('error event');
+  });
+
+  global._mongoClientPromise = client.connect()
+    .then((c) => {
+      console.log('✅ MongoClient connected (pool ≤5)');
+      return c;
+    })
+    .catch((err) => {
+      invalidate(`initial connect failed: ${(err as Error).message}`);
+      throw err;
+    });
+
+  return global._mongoClientPromise;
+}
+
+// Thenable wrapper. `await clientPromise` triggers .then(), which calls
+// getActiveClient() — so every awaited use of the default export runs the
+// health check. Existing callers keep working unchanged.
+const clientPromise: PromiseLike<MongoClient> = {
+  then(onFulfilled, onRejected) {
+    return getActiveClient().then(onFulfilled, onRejected);
+  },
+};
+
+export default clientPromise as Promise<MongoClient>;


### PR DESCRIPTION
## Summary
Fixes the void-stuck-markets cron failure pattern reported via GitHub Actions email. Latest 4 of 5 runs were failing with:

```
Status: 500
Response: {"ok":false,"error":"Internal server error","detail":"connection 1 to 89.192.8.190:27017 closed"}
```

`src/lib/mongodb.ts` cached the connect-promise forever. When Atlas closed the socket (idle pause / replica-set failover), the cached promise still resolved to a dead `MongoClient` and the next invocation got a corpse → 500. Same root cause as the earlier `serverSelectionTimeoutMS` bump (#358), but bumping the timeout only masked it for cold starts; this is the cached-stale-socket case.

## Approach
Self-heal the cache without breaking the 52 callsites:
- Attach `close` / `topologyClosed` / `error` listeners on the `MongoClient` that null `global._mongoClientPromise`.
- Replace the static default export with a **thenable** that runs `getActiveClient()` on every `await`. `getActiveClient` admin-pings the cached client; if the ping fails, invalidate and rebuild.
- On initial-connect rejection, invalidate so the next request isn't permanently stuck on a rejected promise.

No callsite changes. `await clientPromise` still resolves to a `MongoClient`.

## Cost
~ms-scale admin ping per request. Acceptable for stopping the cron from page-erroring every 6h.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [ ] After deploy: re-run void-stuck-markets workflow manually from GitHub UI; expect 200.
- [ ] Watch next 4 scheduled runs (next 24h) — all should succeed.
- [ ] If any DB-touching route shows unexplained latency, ping overhead is the suspect (revert path: keep listeners, drop the ping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
